### PR TITLE
propsで状態を渡せるよう期間選択ボタン周りの実装を整理

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,15 @@
-import React from 'react'
-import { ChakraProvider } from '@chakra-ui/react'
+import React, { useState } from 'react'
 import Header from './components/Header'
 import AggregationPeriodButtons from './components/AggregationPeriodButtons'
 
-export const App = () => (
+const App = () => {
+    const [selectedPeriod, setSelectedPeriod] = useState('daily')
+    return (
     <ChakraProvider>
         <Header></Header>
-        <AggregationPeriodButtons></AggregationPeriodButtons>
+            <AggregationPeriodButtons onSelectedPeriod={(period: string) => setSelectedPeriod(period)}></AggregationPeriodButtons>
     </ChakraProvider>
 )
+}
 
 export default App

--- a/src/components/AggregationPeriodButtons.tsx
+++ b/src/components/AggregationPeriodButtons.tsx
@@ -1,12 +1,69 @@
 import React from 'react'
 import { ButtonGroup, Box, Flex } from '@chakra-ui/react'
+type Props = {
+    onSelectedPeriod: (selectedPeriod: string) => void
+}
 
-const AggregationPeriodButtons = () => {
+const Options = [
+    {
+        borderColor: 'teal.50',
+        bg: 'teal.200',
+        hoverBackground: 'teal.300',
+        active: {
+            bg: '#dddfe2',
+            transform: 'scale(0.98)',
+            borderColor: 'teal.50',
+        },
+        period: 'hourly',
+    },
+    {
+        borderColor: 'teal.50',
+        bg: 'teal.300',
+        hoverBackground: 'teal.400',
+        active: {
+            bg: '#dddfe2',
+            transform: 'scale(0.98)',
+            borderColor: 'teal.50',
+        },
+        period: 'daily',
+    },
+    {
+        borderColor: 'teal.50',
+        bg: 'teal.400',
+        hoverBackground: 'teal.500',
+        active: {
+            bg: '#dddfe2',
+            transform: 'scale(0.98)',
+            borderColor: 'teal.50',
+        },
+        period: 'weekly',
+    },
+    {
+        borderColor: 'teal.50',
+        bg: 'teal.500',
+        hoverBackground: 'teal.600',
+        active: {
+            bg: '#dddfe2',
+            transform: 'scale(0.98)',
+            borderColor: 'teal.50',
+        },
+        period: 'monthly',
+    },
+]
+
+const AggregationPeriodButtons = ({ onSelectedPeriod }: Props) => {
     return (
-        <div>
-            <Flex justify="right">
-                <ButtonGroup mt={7} mr={7} margin-left="auto" spacing={0}>
+        <Flex justify="right">
+            <ButtonGroup mt={7} mr={7} margin-left="auto" spacing={0} overflow="hidden" borderRadius="12">
+                {Options.map((value) => (
                     <Box
+                        key={value.period}
+                        borderColor={value.borderColor}
+                        bg={value.bg}
+                        _hover={{ bg: value.hoverBackground }}
+                        _active={value.active}
+                        onClick={() => onSelectedPeriod(value.period)}
+                        color="white"
                         as="button"
                         height="40px"
                         width="92px"
@@ -14,105 +71,17 @@ const AggregationPeriodButtons = () => {
                         transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
                         border="1px"
                         px="8px"
-                        borderRadius="6px 0 0 6px"
-                        borderColor="teal.50"
                         fontSize="14px"
                         fontWeight="semibold"
-                        bg="teal.200"
-                        color="white"
-                        _hover={{ bg: 'teal.300' }}
-                        _active={{
-                            bg: '#dddfe2',
-                            transform: 'scale(0.98)',
-                            borderColor: 'teal.50',
-                        }}
                         _focus={{
                             boxShadow: '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
                         }}
                     >
-                        hour
+                        {value.period}
                     </Box>
-                    <Box
-                        as="button"
-                        height="40px"
-                        width="92px"
-                        lineHeight="1.2"
-                        transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
-                        border="1px"
-                        borderColor="teal.50"
-                        px="8px"
-                        borderRadius="0"
-                        fontSize="14px"
-                        fontWeight="semibold"
-                        bg="teal.300"
-                        color="white"
-                        _hover={{ bg: 'teal.400' }}
-                        _active={{
-                            bg: '#dddfe2',
-                            transform: 'scale(0.98)',
-                            borderColor: '#bec3c9',
-                        }}
-                        _focus={{
-                            boxShadow: '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
-                        }}
-                    >
-                        daily
-                    </Box>
-                    <Box
-                        as="button"
-                        height="40px"
-                        width="92px"
-                        lineHeight="1.2"
-                        transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
-                        border="1px"
-                        borderColor="teal.50"
-                        px="8px"
-                        borderRadius="0"
-                        fontSize="14px"
-                        fontWeight="semibold"
-                        bg="teal.400"
-                        color="white"
-                        _hover={{ bg: 'teal.500' }}
-                        _active={{
-                            bg: '#dddfe2',
-                            transform: 'scale(0.98)',
-                            borderColor: '#bec3c9',
-                        }}
-                        _focus={{
-                            boxShadow: '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
-                        }}
-                    >
-                        weekly
-                    </Box>
-                    <Box
-                        as="button"
-                        height="40px"
-                        width="92px"
-                        lineHeight="1.2"
-                        transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
-                        border="1px"
-                        borderColor="teal.50"
-                        px="8px"
-                        borderRadius="0 6px 6px 0"
-                        fontSize="14px"
-                        fontWeight="semibold"
-                        bg="teal.500"
-                        color="white"
-                        _hover={{ bg: 'teal.600' }}
-                        _active={{
-                            bg: '#dddfe2',
-                            transform: 'scale(0.98)',
-                            borderColor: '#bec3c9',
-                        }}
-                        _focus={{
-                            boxShadow: '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
-                        }}
-                    >
-                        monthly
-                    </Box>
-                </ButtonGroup>
-            </Flex>
-        </div>
+                ))}
+            </ButtonGroup>
+        </Flex>
     )
 }
 

--- a/src/entry.tsx
+++ b/src/entry.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { App } from './App'
+import App from './App'
 
 ReactDOM.render(<App />, document.getElementById('root'))


### PR DESCRIPTION
## やったこと
- ベタ書きしていたボタンの実装をリファクタ
- 押下しているボタンの状態を親コンポーネントで取得できるよう実装

## できるようになること
- 期間選択のpropsを他コンポーネントに流せる

## 動作確認
```sh
yarn install
yarn start
```

## その他
