### PR TITLE
publishedAfterをstringで指定してapiを投げられるよう引数の整形

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
+        "date-fns": "^2.28.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     }

--- a/src/apis/youtubeApiWrapper.ts
+++ b/src/apis/youtubeApiWrapper.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { API_KEY } from '../../local/constants'
+import { subMonths, subWeeks, subDays, subHours, formatRFC3339 } from 'date-fns'
 type youtubeSearchTypes = {
     part?: string
     channelId?: string
@@ -81,11 +82,8 @@ class YoutubeApiWrapper {
      * pageToken パラメータには、返される結果セットに含める特定のページを指定します。
      * API レスポンスでは、nextPageToken と prevPageToken プロパティは取得可能な他のページを表します。
      * @param {Date} publishedAfter
+     * stringのhourly, daily, weekly, monthlyを渡すことができます。それ以外の値ではすべて(1990-01-01T00:00:00Z)を返します。
      * publishedAfter パラメータは、指定した日時より後に作成されたリソースのみが API レスポンスに含まれるように指定します。
-     * この値は RFC 3339 形式の date-time 値です（1970-01-01T00:00:00Z）。
-     * @param {Date} publishedBefore
-     * publishedBefore パラメータは、指定した日時より前に作成されたリソースのみが API レスポンスに含まれるように指定します。
-     * この値は RFC 3339 形式の date-time 値です（1970-01-01T00:00:00Z）。
      * @param {string} q
      * q パラメータは検索クエリを指定します。
      * @param {string} regionCode
@@ -170,7 +168,7 @@ class YoutubeApiWrapper {
         order = 'viewCount',
         pageToken = '',
         publishedAfter = '',
-        publishedBefore = '',
+        // publishedBefore = '2015-01-01T00:00:00Z',
         q = '',
         regionCode = '',
         safeSearch = 'none',
@@ -196,8 +194,8 @@ class YoutubeApiWrapper {
                 maxResults: maxResults,
                 order: order,
                 pageToken: pageToken,
-                // publishedAfter: publishedAfter,
-                // publishedBefore: publishedBefore,
+                publishedAfter: formatRFC3339(this.publishedAfterTime(publishedAfter)),
+                publishedBefore: formatRFC3339(new Date()),
                 q: q,
                 // regionCode: regionCode,
                 safeSearch: safeSearch,
@@ -272,6 +270,23 @@ class YoutubeApiWrapper {
                 videoCategoryId: videoCategoryId,
             },
         })
+    }
+
+    private publishedAfterTime(selectedPeriod: string) {
+        const currentTime = new Date()
+        if (selectedPeriod === 'hourly') {
+            return subHours(currentTime, 1)
+        }
+        if (selectedPeriod === 'daily') {
+            return subDays(currentTime, 1)
+        }
+        if (selectedPeriod === 'weekly') {
+            return subWeeks(currentTime, 1)
+        }
+        if (selectedPeriod === 'monthly') {
+            return subMonths(currentTime, 1)
+        }
+        return new Date('1990-01-01T00:00:00')
     }
 }
 

--- a/src/apis/youtubeApiWrapper.ts
+++ b/src/apis/youtubeApiWrapper.ts
@@ -168,7 +168,6 @@ class YoutubeApiWrapper {
         order = 'viewCount',
         pageToken = '',
         publishedAfter = '',
-        // publishedBefore = '2015-01-01T00:00:00Z',
         q = '',
         regionCode = '',
         safeSearch = 'none',

--- a/src/apis/youtubeApiWrapper.ts
+++ b/src/apis/youtubeApiWrapper.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import { API_KEY } from '../../local/constants'
 import { subMonths, subWeeks, subDays, subHours, formatRFC3339 } from 'date-fns'
+type publishedAfterTypes = 'hourly' | 'daily' | 'weekly' | 'monthly'
+
 type youtubeSearchTypes = {
     part?: string
     channelId?: string
@@ -9,7 +11,7 @@ type youtubeSearchTypes = {
     channelType?: string
     eventType?: string
     pageToken?: string
-    publishedAfter?: string
+    publishedAfter?: publishedAfterTypes
     publishedBefore?: string
     q: string
     regionCode?: string
@@ -167,7 +169,7 @@ class YoutubeApiWrapper {
         maxResults = 5,
         order = 'viewCount',
         pageToken = '',
-        publishedAfter = '',
+        publishedAfter,
         q = '',
         regionCode = '',
         safeSearch = 'none',
@@ -214,7 +216,7 @@ class YoutubeApiWrapper {
     }
 
     /**
-     * youtubeAPIのVideosリクエストを利用しJSONが格納されたPromeiseオブジェクトを返す
+     * youtubeAPIのVideosリクエストを利用しJSONが格納されたPromiseオブジェクトを返す
      * @param {string} part
      * part パラメータには、API レスポンスに含まれる 1 つまたは複数の video リソース プロパティをカンマ区切りリストの形式で指定します。
      * パラメータ値に指定できる part 名は、
@@ -277,7 +279,7 @@ class YoutubeApiWrapper {
      * stringでhourly/daily/weekly/monthly
      * @return {Date} 現在時刻から取得期間分の差分をとった日付を返却
      */
-    private publishedAfterTime(selectedPeriod: string): Date {
+    private publishedAfterTime(selectedPeriod: publishedAfterTypes | undefined): Date {
         const currentTime = new Date()
         if (selectedPeriod === 'hourly') {
             return subHours(currentTime, 1)

--- a/src/apis/youtubeApiWrapper.ts
+++ b/src/apis/youtubeApiWrapper.ts
@@ -271,7 +271,13 @@ class YoutubeApiWrapper {
         })
     }
 
-    private publishedAfterTime(selectedPeriod: string) {
+    /**
+     * @param {string} selectedPeriod
+     * 動画取得期間を選択する
+     * stringでhourly/daily/weekly/monthly
+     * @return {Date} 現在時刻から取得期間分の差分をとった日付を返却
+     */
+    private publishedAfterTime(selectedPeriod: string): Date {
         const currentTime = new Date()
         if (selectedPeriod === 'hourly') {
             return subHours(currentTime, 1)

--- a/src/apis/youtubeApiWrapper.ts
+++ b/src/apis/youtubeApiWrapper.ts
@@ -169,7 +169,7 @@ class YoutubeApiWrapper {
         maxResults = 5,
         order = 'viewCount',
         pageToken = '',
-        publishedAfter,
+        publishedAfter = 'monthly',
         q = '',
         regionCode = '',
         safeSearch = 'none',
@@ -279,7 +279,7 @@ class YoutubeApiWrapper {
      * stringでhourly/daily/weekly/monthly
      * @return {Date} 現在時刻から取得期間分の差分をとった日付を返却
      */
-    private publishedAfterTime(selectedPeriod: publishedAfterTypes | undefined): Date {
+    private publishedAfterTime(selectedPeriod: publishedAfterTypes): Date {
         const currentTime = new Date()
         if (selectedPeriod === 'hourly') {
             return subHours(currentTime, 1)
@@ -293,7 +293,7 @@ class YoutubeApiWrapper {
         if (selectedPeriod === 'monthly') {
             return subMonths(currentTime, 1)
         }
-        return new Date('1990-01-01T00:00:00')
+        return subMonths(currentTime, 1)
     }
 }
 


### PR DESCRIPTION
## やったこと
publishedAfterをstring(hourly, daily, weekly, monthly)で指定して渡せるよう整形のロジックを実装した

## できるようになること
fetchSearchApiの引数に検索期間指定できる

## 動作確認
1. `webpack.config.js`のentryをapiのテストファイルにする
2. テストのfetchASearchApiの引数にpublishedAfterを入れてみる

## その他
- stringで指定するやり方でいいのか怪しい